### PR TITLE
refactor: use '->' instead of ':' for fn return types

### DIFF
--- a/src/ch01-02-hello-fibonacci.md
+++ b/src/ch01-02-hello-fibonacci.md
@@ -24,15 +24,15 @@ Open up the new source file and enter the code in Listing 1-1.
 Filename: hello_fibonacci.mun
 
 ```mun
-fn fibonacci5():int {
+fn fibonacci5() -> int {
     fibonacci(5)
 }
 
-fn fibonacci(n:int):int {
+fn fibonacci(n: int) -> int {
     if n <= 1 {
         n
     } else {
-        fibonacci(n-1) + fibonacci(n-2)
+        fibonacci(n - 1) + fibonacci(n - 2)
     }
 }
 ```

--- a/src/ch01-03-hello-hot-reloading.md
+++ b/src/ch01-03-hello-hot-reloading.md
@@ -7,15 +7,15 @@ following example illustrates how you can create a hot reloadable application by
 Filename: hello_fibonacci.mun
 
 ```mun
-fn fibonacci5():int {
+fn fibonacci5() -> int {
     fibonacci(5)
 }
 
-fn fibonacci(n:int):int {
+fn fibonacci(n: int) -> int {
     if n <= 1 {
         n
     } else {
-        fibonacci(n-1) + fibonacci(n-2)
+        fibonacci(n - 1) + fibonacci(n - 2)
     }
 }
 ```

--- a/src/ch02-01-values-and-types.md
+++ b/src/ch02-01-values-and-types.md
@@ -18,8 +18,8 @@ forced to explicitly annotate variables in a few locations to ensure a contract
 between interdependent code.
 
 ```mun
-fn bar(a:int):int {
-    let foo = 3 + a
+fn bar(a: int) -> int {
+    let foo = 3 + a;
     foo
 }
 ```
@@ -48,14 +48,14 @@ expression in them. Blocks can therefore also be used on the right hand side of 
 `let` statement.
 
 ```mun
-fn foo():int {
+fn foo() -> int {
     let bar = {
         let b = 3;
-        b+3
-    }
+        b + 3
+    };
 
     // `bar` has a value 6
-    bar+3
+    bar + 3
 }
 ```
 
@@ -64,14 +64,14 @@ expressions. However, explicit `return` statements always return from the
 function, not from the block:
 
 ```mun
-fn foo():int {
+fn foo() -> int {
     let bar = {
         let b = 3;
-        return b+3
-    }
+        return b + 3;
+    };
 
     // This code will never be executed
-    return bar+3;
+    return bar + 3;
 }
 ```
 


### PR DESCRIPTION
(also format some things and add a few semicolons for clarity)